### PR TITLE
Fixed missing report info, + uncaught exception

### DIFF
--- a/RedfishInteropValidator.py
+++ b/RedfishInteropValidator.py
@@ -256,10 +256,10 @@ def validateURITree(URI, uriName, profile, expectedType=None, expectedSchema=Non
 
                 if autoExpand and linkType is not None:
                     linkSuccess, linkCounts, linkResults, innerLinks, linkobj = \
-                        validateSingleURI(linkURI, profile, "{} -> {}".format(uriName, linkName), linkType, linkSchema, innerJson, parent=parent)
+                        validateSingleURI(linkURI, profile, linkURI, linkType, linkSchema, innerJson, parent=parent)
                 else:
                     linkSuccess, linkCounts, linkResults, innerLinks, linkobj = \
-                        validateSingleURI(linkURI, profile, "{} -> {}".format(uriName, linkName), linkType, linkSchema, parent=parent)
+                        validateSingleURI(linkURI, profile, linkURI, linkType, linkSchema, parent=parent)
 
                 allLinks.add(linkURI)
 
@@ -332,8 +332,6 @@ def validateURITree(URI, uriName, profile, expectedType=None, expectedSchema=Non
             'counts':rcounts,\
             'messages':rmessages, 'errors':rerror.getvalue(), 'warns': '',\
             'rtime':'', 'context':'', 'fulltype':''}
-    for l in sorted(allLinks):
-        print(l)
     print(len(allLinks))
     finalResults.update(results)
     rerror.close()

--- a/commonInterop.py
+++ b/commonInterop.py
@@ -361,7 +361,7 @@ def validatePropertyRequirement(propResourceObj, entry, decodedtuple, itemname, 
                     msgs.extend(complexMsgs)
                     counts.update(complexCounts)
             else:
-                rsvLogger.info('complex {} is missing or not a dictionary'.format(itemname + '.' + item, None))
+                rsvLogger.info('complex {} is missing or not a dictionary'.format(itemname))
     return msgs, counts
 
 

--- a/tohtml.py
+++ b/tohtml.py
@@ -142,7 +142,7 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick):
         val = results[item]
         rtime = '(response time: {})'.format(val['rtime'])
 
-        if len(val['messages']) == 0:
+        if len(val['messages']) == 0 and len(val['errors']) == 0:
             continue
 
         # uri block


### PR DESCRIPTION
1) replace uriName parent string with uri to serve as unique identifier (the former tree no longer works like it does in validator), no longer being overridden by similar parent trees

2) remove URI printing

3) remove "item" variable that is out of the scope of else block

4) allow any resource with errors that may/may not be part of the profile to be included in the final report