### PR TITLE
Fix verboseout error

### DIFF
--- a/commonInterop.py
+++ b/commonInterop.py
@@ -8,7 +8,7 @@ import traverseService as rst
 from enum import Enum
 from collections import Counter
 
-rsvLogger = rst.getLogger()
+from RedfishInteropValidator import rsvLogger
 
 config = {'WarnRecommended': False, 'WriteCheck': False}
 


### PR DESCRIPTION
When running tests, commonInterop will fail with the error:
AttributeError: 'Logger' object has no attribute 'verboseout'

This change fixes that issue.