### PR TITLE
Fix-126: Validate min version fix

### DIFF
--- a/common/interop.py
+++ b/common/interop.py
@@ -250,8 +250,14 @@ def validateMinVersion(version, profile_entry):
 
     paramPass = True
     for a, b in zip(profile_entry_split, payload_split):
-        b = 0 if b is None else int(b) if b.isnumeric() else b
-        a = 0 if a is None else int(a) if a.isnumeric() else a
+        if b.isnumeric() and a.isnumeric() and b is not None and a is not None:
+            b = int(b)
+            a = int(a)
+        else:
+            b = 0 if b is None else b
+            a = 0 if a is None else b
+        if type(b) is not type(a):
+            break
         if (b > a):
             break
         if (b < a):

--- a/common/interop.py
+++ b/common/interop.py
@@ -250,8 +250,8 @@ def validateMinVersion(version, profile_entry):
 
     paramPass = True
     for a, b in zip(profile_entry_split, payload_split):
-        b = 0 if b is None else b
-        a = 0 if a is None else a
+        b = 0 if b is None else int(b) if b.isnumeric() else b
+        a = 0 if a is None else int(a) if a.isnumeric() else a
         if (b > a):
             break
         if (b < a):


### PR DESCRIPTION
Avoid string comparison for versions, since versions like 1.15.0 were being considered less recent than versions like 1.5.2.