### PR TITLE
Unify to use logger.warning

### DIFF
--- a/RedfishInteropValidator.py
+++ b/RedfishInteropValidator.py
@@ -173,7 +173,7 @@ def main(argslist=None, configfile=None):
 
     if pmode not in ['tree', 'single', 'singlefile', 'treefile', 'default']:
         pmode = 'Default'
-        my_logger.warn('PayloadMode or path invalid, using Default behavior')
+        my_logger.warning('PayloadMode or path invalid, using Default behavior')
     if 'file' in pmode:
         if ppath is not None and os.path.isfile(ppath):
             with open(ppath) as f:

--- a/common/interop.py
+++ b/common/interop.py
@@ -66,7 +66,7 @@ def validateRequirement(profile_entry, rf_payload_item=None, conditional=False, 
     if profile_entry == "Recommended" and propDoesNotExist:
         my_logger.info('\tItem is recommended but does not exist')
         if config['WarnRecommended']:
-            my_logger.warn('\tItem is recommended but does not exist, escalating to WARN')
+            my_logger.warning('\tItem is recommended but does not exist, escalating to WARN')
             paramPass = sEnum.WARN
 
     my_logger.debug('\tpass ' + str(paramPass))
@@ -277,7 +277,7 @@ def checkConditionalRequirementResourceLevel(r_exists, profile_entry, itemname):
     my_logger.debug('Evaluating conditionalRequirements')
     if "SubordinateToResource" in profile_entry:
         isSubordinate = False
-        my_logger.warn('SubordinateToResource not supported')
+        my_logger.warning('SubordinateToResource not supported')
         return isSubordinate
     elif "CompareProperty" in profile_entry:
         # find property in json payload by working backwards thru objects
@@ -290,7 +290,7 @@ def checkConditionalRequirementResourceLevel(r_exists, profile_entry, itemname):
             my_logger.error("Invalid Profile - CompareValues is required for CompareProperty but not found")
             raise ValueError('CompareValues missing with CompareProperty')
         if "CompareValues" in profile_entry and profile_entry['CompareType'] in ['Absent', 'Present']:
-            my_logger.warn("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
+            my_logger.warning("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
         # compatability with old version, deprecate with versioning
 
         present = r_exists.get(profile_entry.get('CompareProperty'), False)
@@ -341,7 +341,7 @@ def checkConditionalRequirement(propResourceObj, profile_entry, rf_payload_tuple
             my_logger.error("Invalid Profile - CompareValues is required for CompareProperty but not found")
             raise ValueError('CompareValues missing with CompareProperty')
         if "CompareValues" in profile_entry and profile_entry['CompareType'] in ['Absent', 'Present']:
-            my_logger.warn("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
+            my_logger.warning("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
         while (rf_payload_item is None or comparePropNames[0] not in rf_payload_item) and rf_payload is not None:
             rf_payload_item, rf_payload = rf_payload
         if rf_payload_item is None:
@@ -505,7 +505,7 @@ def validateActionRequirement(profile_entry, rf_payload_tuple, actionname):
             if values_array is None:
                 values_array = rf_payload_item.get(str(k) + '@Redfish.AllowableValues', 'DNE')
             if values_array == 'DNE':
-                my_logger.warn('\tNo such ActionInfo exists for this Action, and no AllowableValues exists.  Cannot validate the following parameters: {}'.format(k))
+                my_logger.warning('\tNo such ActionInfo exists for this Action, and no AllowableValues exists.  Cannot validate the following parameters: {}'.format(k))
                 msg = msgInterop('', item, '-', '-', sEnum.WARN)
                 msg.name = "{}.{}.{}".format(actionname, k, msg.name)
                 msgs.append(msg)
@@ -523,10 +523,10 @@ def validateActionRequirement(profile_entry, rf_payload_tuple, actionname):
                             item["RecommendedValues"], values_array)
                     msg.name = msg.name.replace('Supported', 'Recommended')
                     if config['WarnRecommended'] and not success:
-                        my_logger.warn('\tRecommended parameters do not all exist, escalating to WARN')
+                        my_logger.warning('\tRecommended parameters do not all exist, escalating to WARN')
                         msg.success = sEnum.WARN
                     elif not success:
-                        my_logger.warn('\tRecommended parameters do not all exist, but are not Mandatory')
+                        my_logger.warning('\tRecommended parameters do not all exist, but are not Mandatory')
                         msg.success = sEnum.PASS
 
                     msgs.append(msg)
@@ -546,7 +546,7 @@ def compareRedfishURI(expected_uris, uri, my_id):
             e_left = regex.sub('[a-zA-Z0-9_.-]+', e_left)
             if regex.match(e_right):
                 if my_id is None:
-                    my_logger.warn('No Id provided by payload')
+                    my_logger.warning('No Id provided by payload')
                 e_right = str(my_id)
             e_compare_to = '/'.join([e_left, e_right])
             if re.fullmatch(e_compare_to, uri) is not None:
@@ -634,4 +634,3 @@ def validateInteropResource(propResourceObj, interop_profile, rf_payload):
             counts['fail.{}'.format(item.name)] += 1
         counts['totaltests'] += 1
     return msgs, counts
-

--- a/common/profile.py
+++ b/common/profile.py
@@ -144,11 +144,10 @@ def getProfiles(profile, dirname, chain=None, online=False):
                     filehandle.close()
                     data = json.loads(data)
                     if targetVersion > fileVersion:
-                        my_logger.warn('File version smaller than target MinVersion')
+                        my_logger.warning('File version smaller than target MinVersion')
                 else:
                     my_logger.error('Could not acquire this profile {} {}'.format(targetName, repo))
                     continue
 
             alldata.extend(getProfiles(data, dirname, chain))
     return alldata
-

--- a/traverseInterop.py
+++ b/traverseInterop.py
@@ -110,10 +110,10 @@ class rfService():
         # get Version
         success, data, status, delay = self.callResourceURI('/redfish/v1')
         if not success:
-            traverseLogger.warn('Could not get ServiceRoot')
+            traverseLogger.warning('Could not get ServiceRoot')
         else:
             if 'RedfishVersion' not in data:
-                traverseLogger.warn('Could not get RedfishVersion from ServiceRoot')
+                traverseLogger.warning('Could not get RedfishVersion from ServiceRoot')
             else:
                 traverseLogger.info('Redfish Version of Service: {}'.format(data['RedfishVersion']))
                 target_version = data['RedfishVersion']
@@ -164,7 +164,7 @@ class rfService():
         # rs-assertion: handle redirects?  and target permissions
         # rs-assertion: require no auth for serviceroot calls
         if URILink is None:
-            traverseLogger.warn("This URI is empty!")
+            traverseLogger.warning("This URI is empty!")
             return False, None, -1, 0
 
         config = self.config
@@ -260,7 +260,7 @@ class rfService():
                 elif 'text/xml' in contenttype:
                     # non-service schemas can use "text/xml" Content-Type
                     if inService:
-                        traverseLogger.warn(
+                        traverseLogger.warning(
                                 "Incorrect content type 'text/xml' for file within service {}".format(URILink))
                     decoded = response.text
                 else:
@@ -315,7 +315,7 @@ class rfService():
 
 def callResourceURI(URILink):
     if currentService is None:
-        traverseLogger.warn("The current service is not setup!  Program must configure the service before contacting URIs")
+        traverseLogger.warning("The current service is not setup!  Program must configure the service before contacting URIs")
         raise RuntimeError
     else:
         return currentService.callResourceURI(URILink)
@@ -445,7 +445,7 @@ class ResourceObj:
                     traverseLogger.error("{} {}: Expected format is /path/to/uri, but received: {}".format(uri, key, decoded[key]))
                 else:
                     if decoded[key] != uri:
-                        traverseLogger.warn("{} {}: Expected @odata.id to match URI link {}".format(uri, key, decoded[key]))
+                        traverseLogger.warning("{} {}: Expected @odata.id to match URI link {}".format(uri, key, decoded[key]))
             elif key == '@odata.count':
                 paramPass = isinstance(decoded[key], int)
                 if not paramPass:
@@ -455,7 +455,7 @@ class ResourceObj:
                 paramPass = re.match(
                     '/redfish/v1/\$metadata#([a-zA-Z0-9_.-]*\.)[a-zA-Z0-9_.-]*', decoded[key]) is not None
                 if not paramPass:
-                    traverseLogger.warn("{} {}: Expected format is /redfish/v1/$metadata#ResourceType, but received: {}".format(uri, key, decoded[key]))
+                    traverseLogger.warning("{} {}: Expected format is /redfish/v1/$metadata#ResourceType, but received: {}".format(uri, key, decoded[key]))
                     messages[key] = (decoded[key], 'odata',
                                     'Exists',
                                     'WARN')

--- a/validateResource.py
+++ b/validateResource.py
@@ -139,7 +139,7 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
                 my_logger.error('@odata.id of ReferenceableMember does not point to the correct object: {}'.format(odata_id))
                 counts['badOdataIdResolution'] += 1
         else:
-            my_logger.warn('No parent found with which to test @odata.id of ReferenceableMember')
+            my_logger.warning('No parent found with which to test @odata.id of ReferenceableMember')
 
     # if not successPayload:
     #     counts['failPayloadError'] += 1
@@ -351,4 +351,3 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
     rerror.close()
 
     return validateSuccess, counts, finalResults, refLinks, thisobj
-


### PR DESCRIPTION
It's an enhancement to use `logger.warning` instead of `logger.warn` (which is deprecated)