### PR TITLE
Get the correct rf_payload_item from rf_payload_tuple

### DIFF
--- a/common/interop.py
+++ b/common/interop.py
@@ -270,40 +270,6 @@ def validateMinVersion(version, profile_entry):
         paramPass
 
 
-def checkConditionalRequirementResourceLevel(r_exists, profile_entry, itemname):
-    """
-    Returns boolean if profile_entry's conditional is true or false
-    """
-    my_logger.debug('Evaluating conditionalRequirements')
-    if "SubordinateToResource" in profile_entry:
-        isSubordinate = False
-        my_logger.warning('SubordinateToResource not supported')
-        return isSubordinate
-    elif "CompareProperty" in profile_entry:
-        # find property in json payload by working backwards thru objects
-        # rf_payload tuple is designed just for this piece, since there is
-        # no parent in dictionaries
-        if "CompareType" not in profile_entry:
-            my_logger.error("Invalid Profile - CompareType is required for CompareProperty but not found")
-            raise ValueError('CompareType missing with CompareProperty')
-        if "CompareValues" not in profile_entry and profile_entry['CompareType'] not in ['Absent', 'Present']:
-            my_logger.error("Invalid Profile - CompareValues is required for CompareProperty but not found")
-            raise ValueError('CompareValues missing with CompareProperty')
-        if "CompareValues" in profile_entry and profile_entry['CompareType'] in ['Absent', 'Present']:
-            my_logger.warning("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
-        # compatability with old version, deprecate with versioning
-
-        present = r_exists.get(profile_entry.get('CompareProperty'), False)
-        compareType = profile_entry.get("CompareType", profile_entry.get("Comparison"))
-
-        # only supports absent and present
-
-        return checkComparison('DNE' if not present else '[Object]', compareType, None)[1]
-    else:
-        my_logger.error("Invalid Profile - No conditional given")
-        raise ValueError('No conditional given for Comparison')
-
-
 def checkConditionalRequirement(propResourceObj, profile_entry, rf_payload_tuple):
     """
     Returns boolean if profile_entry's conditional is true or false

--- a/common/interop.py
+++ b/common/interop.py
@@ -342,7 +342,13 @@ def checkConditionalRequirement(propResourceObj, profile_entry, rf_payload_tuple
         if "CompareValues" in profile_entry and profile_entry['CompareType'] in ['Absent', 'Present']:
             my_logger.warning("Invalid Profile - CompareValues is not required for CompareProperty Absent or Present ")
 
-        _, (rf_payload_item, _) = rf_payload_tuple
+        rf_payload_item, rf_payload = rf_payload_tuple
+        while rf_payload is not None and (not isinstance(rf_payload_item, dict) or comparePropNames[0] not in rf_payload_item):
+            rf_payload_item, rf_payload = rf_payload
+
+        if rf_payload_item is None:
+            my_logger.error('Could not acquire expected CompareProperty {}'.format(comparePropNames[0]))
+            return False
 
         compareProp = rf_payload_item.get(comparePropNames[0], 'DNE')
         if (compareProp != 'DNE') and len(comparePropNames) > 1:

--- a/validateResource.py
+++ b/validateResource.py
@@ -300,41 +300,6 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
     else:
         resultEnum = interop.sEnum.FAIL
 
-    # for item in resource_info:
-    #     # thisobj does not exist if we didn't find the first resource
-    #     if thisobj and item == getType(thisobj.typeobj.fulltype):
-    #         continue
-
-    #     exists = r_exists.get(item, False)
-
-    #     if "ConditionalRequirements" in resource_info[item]:
-    #         innerList = resource_info[item]["ConditionalRequirements"]
-    #         for condreq in innerList:
-    #             if interop.checkConditionalRequirementResourceLevel(r_exists, condreq, item):
-    #                 my_logger.info(
-    #                     'Service Conditional for {} applies'.format(item))
-    #                 req = condreq.get("ReadRequirement", "Mandatory")
-    #                 rmessages.append(
-    #                     interop.msgInterop(item + '.Conditional.ReadRequirement',
-    #                                              req, 'Must Exist' if req == "Mandatory" else 'Any', 'DNE' if not exists else 'Exists',
-    #                                              resultEnum if not exists and req == "Mandatory" else interop.sEnum.PASS))
-    #             else:
-    #                 my_logger.info(
-    #                     'Service Conditional for {} does not apply'.format(item))
-
-    #     req = resource_info[item].get("ReadRequirement", "Mandatory")
-
-    #     if not exists:
-    #         rmessages.append(
-    #             interop.msgInterop(item + '.ReadRequirement', req,
-    #                                      'Must Exist' if req == "Mandatory" else 'Any', 'DNE',
-    #                                      resultEnum if req == "Mandatory" else interop.sEnum.PASS))
-    #     else:
-    #         rmessages.append(
-    #             interop.msgInterop(item + '.ReadRequirement', req,
-    #                                      'Must Exist' if req == "Mandatory" else 'Any', 'Exists',
-    #                                      interop.sEnum.PASS))
-
     for item in rmessages:
         if item.success == interop.sEnum.WARN:
             rcounts['warn'] += 1


### PR DESCRIPTION
* Fix the regression of https://github.com/DMTF/Redfish-Interop-Validator/pull/135/files. It got the incorrect `rf_payload_item` when checking a nested property. Change it back to the original method and add the type check to ensure it also solve the #134 problem.
* Remove the unused code related to `checkConditionalRequirementResourceLevel`.

BTW, is there anyone familiar with the usage of `rf_payload_tuple`? Could we have a more detailed documentation about how to set/use it? I tried to refine it but found it a bit hard to trace because of the recursions & it is used by multiple functions. 