### PR TITLE
Fix the resource GET result when running multiple profiles

### DIFF
--- a/validateResource.py
+++ b/validateResource.py
@@ -111,6 +111,7 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
         return False, counts, results, None, None
 
     counts['passGet'] += 1
+    results[uriName]['success'] = True
 
     # verify odata type
     objRes = profile.get('Resources')
@@ -156,7 +157,6 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
     results[uriName]['payload'] = propResourceObj.jsondata
     results[uriName]['context'] = propResourceObj.context
     results[uriName]['fulltype'] = propResourceObj.typename
-    results[uriName]['success'] = True
 
     my_logger.info('\n')
     my_logger.info("*** %s, %s", URI, SchemaType)


### PR DESCRIPTION
The issue only happens when running multiple profiles
with RequiredProfiles.

Root cause: For different profiles, we merge their
results into one final result and for the same URI
the latter result would overwrite the previous one.

For the 'success' attribute which is updated in
validateSingleURI function, it only set to true when
both conditions met:
1. GET is success
2. Current profile have requirements on this resource

If a profile don't have requirements on this resource,
even the GET is success, the property would not be
updated. This patch fixed this issue by updating
that property once the first condition is met.

Signed-off-by: Jordan Chen <jordanchen@google.com>