### PR TITLE
Clarified exit path when invalid credentials are used

### DIFF
--- a/traverseInterop.py
+++ b/traverseInterop.py
@@ -285,7 +285,7 @@ class rfService():
                         cred_type = 'token'
                     else:
                         cred_type = 'username and password'
-                    raise AuthenticationError('Error accessing URI {}. Status code "{} {}". Check {} supplied for "{}" authentication.'
+                    raise AuthenticationError('Error accessing URI {}. Status code "{} {}". Check {} supplied for "{}" authentication.\nAborting test due to invalid credentials.'
                                               .format(URILink, statusCode, responses[statusCode], cred_type, AuthType))
 
         except requests.exceptions.SSLError as e:


### PR DESCRIPTION
Debugging a user issue where it was not clear why the test stopped. Adding additional text to explain that the test is halting due to receiving a 401 status.