### PR TITLE
Test ReadRequirement on Resource-level, misc cleanup

### DIFF
--- a/common/interop.py
+++ b/common/interop.py
@@ -509,22 +509,17 @@ def validateActionRequirement(profile_entry, rf_payload_tuple, actionname):
     # if it doesn't exist, what should not be checked for action
     return msgs, counts
 
-def compareRedfishURI(expected_uris, uri, my_id):
+URI_ID_REGEX = '\{[A-Za-z0-9]*Id\}'
+
+VALID_ID_REGEX = '([A-Za-z0-9.!#$&-;=?\[\]_~])+'
+
+def compareRedfishURI(expected_uris, uri):
     success = False
+    # If we have our URIs
     if expected_uris is not None:
-        regex = re.compile(r"{.*?}")
-        for e in expected_uris:
-            e_left, e_right = tuple(e.rsplit('/', 1))
-            _uri_left, uri_right = tuple(uri.rsplit('/', 1))
-            e_left = regex.sub('[a-zA-Z0-9_.-]+', e_left)
-            if regex.match(e_right):
-                if my_id is None:
-                    my_logger.warning('No Id provided by payload')
-                e_right = str(my_id)
-            e_compare_to = '/'.join([e_left, e_right])
-            if re.fullmatch(e_compare_to, uri) is not None:
-                success = True
-                break
+        my_uri_regex = "^{}$".format("|".join(expected_uris))
+        my_uri_regex = re.sub(URI_ID_REGEX, VALID_ID_REGEX, my_uri_regex)
+        success = re.fullmatch(my_uri_regex, uri) is not None
     else:
         success = True
     return success
@@ -536,7 +531,7 @@ def checkInteropURI(r_obj, profile_entry):
     my_logger.debug('Testing URI \n\t' + str((r_obj.uri, profile_entry)))
 
     my_id, my_uri = r_obj.jsondata.get('Id'), r_obj.uri
-    return compareRedfishURI(profile_entry, my_uri, my_id)
+    return compareRedfishURI(profile_entry, my_uri)
 
 def validateInteropResource(propResourceObj, interop_profile, rf_payload):
     """

--- a/validateResource.py
+++ b/validateResource.py
@@ -339,6 +339,10 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
                         my_logger.info('Validating {} Conditional ReadRequirement'.format(resource_type))
                         my_msg, _ = interop.validateRequirement(expected_requirement, 'Exists' if apply_requirement else 'DNE')
                         my_msg.name = '{}.Conditional.{}'.format(resource_type, my_msg.name)
+                        if uris_applied:
+                            my_msg.expected = "{} at {}".format(my_msg.expected, ", ".join(uris_applied))
+                        if subordinate_condition:
+                            my_msg.expected = "{} under {}".format(my_msg.expected, ", ".join(subordinate_condition))
                         message_list.append(my_msg)
 
             if "ReadRequirement" in profile_entry:
@@ -350,11 +354,12 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
                 else:
                     apply_requirement = resource_exists
 
-                if apply_requirement and expected_requirement:
-                    my_logger.info('Validating {} ReadRequirement'.format(resource_type))
-                    my_msg, _ = interop.validateRequirement(expected_requirement, 'Exists' if apply_requirement else 'DNE')
-                    my_msg.name = '{}.{}'.format(resource_type, my_msg.name)
-                    message_list.append(my_msg)
+                my_logger.info('Validating {} ReadRequirement'.format(resource_type))
+                my_msg, _ = interop.validateRequirement(expected_requirement, 'Exists' if apply_requirement else 'DNE')
+                my_msg.name = '{}.{}'.format(resource_type, my_msg.name)
+                if uris_applied:
+                    my_msg.expected = "{} at {}".format(my_msg.expected, ", ".join(uris_applied))
+                message_list.append(my_msg)
 
     # interop service level checks
     finalResults = {}

--- a/validateResource.py
+++ b/validateResource.py
@@ -345,21 +345,20 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
                             my_msg.expected = "{} under {}".format(my_msg.expected, ", ".join(subordinate_condition))
                         message_list.append(my_msg)
 
-            if "ReadRequirement" in profile_entry:
-                expected_requirement = profile_entry.get("ReadRequirement", "Mandatory")
-                uris_applied = profile_entry.get("URIs")
+            expected_requirement = profile_entry.get("ReadRequirement", "Mandatory")
+            uris_applied = profile_entry.get("URIs")
 
-                if uris_applied:
-                    apply_requirement = any([interop.compareRedfishURI(uris_applied, uri) for uri in uris_found])
-                else:
-                    apply_requirement = resource_exists
+            if uris_applied:
+                apply_requirement = any([interop.compareRedfishURI(uris_applied, uri) for uri in uris_found])
+            else:
+                apply_requirement = resource_exists
 
-                my_logger.info('Validating {} ReadRequirement'.format(resource_type))
-                my_msg, _ = interop.validateRequirement(expected_requirement, 'Exists' if apply_requirement else 'DNE')
-                my_msg.name = '{}.{}'.format(resource_type, my_msg.name)
-                if uris_applied:
-                    my_msg.expected = "{} at {}".format(my_msg.expected, ", ".join(uris_applied))
-                message_list.append(my_msg)
+            my_logger.info('Validating {} ReadRequirement'.format(resource_type))
+            my_msg, _ = interop.validateRequirement(expected_requirement, 'Exists' if apply_requirement else 'DNE')
+            my_msg.name = '{}.{}'.format(resource_type, my_msg.name)
+            if uris_applied:
+                my_msg.expected = "{} at {}".format(my_msg.expected, ", ".join(uris_applied))
+            message_list.append(my_msg)
 
     # interop service level checks
     finalResults = {}

--- a/validateResource.py
+++ b/validateResource.py
@@ -304,8 +304,9 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
                 currentLinks = newLinks
         
         # For every resource check ReadRequirement
-        for resource_type in profile.get('Resources'):
-            profile_entry = profile.get('Resources')[resource_type]
+        resources_in_profile = profile.get('Resources', [])
+        for resource_type in resources_in_profile:
+            profile_entry = resources_in_profile[resource_type]
             apply_requirement, expected_requirement = False, None
 
             # If exist and for what URIs...
@@ -339,7 +340,11 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
             if "ReadRequirement" in profile_entry:
                 expected_requirement = profile_entry.get("ReadRequirement", "Mandatory")
                 uris_applied = profile_entry.get("URIs")
-                uris_found = resource_stats[resource_type]['URIsFound']
+                if resource_type in resource_stats:
+                    uris_found = resource_stats[resource_type]['URIsFound']
+                else:
+                    uris_found = []
+
                 if uris_applied:
                     apply_requirement = any([uri in uris_applied for uri in uris_found])
                 else:


### PR DESCRIPTION
Should now respect ReadRequirement rules that belong to Resource objects such as "Chassis", as well as ConditionalRequirements that expect a higher level ReadRequirement.

Miscellaneous cleanup related to descriptive variable names and imports

Fix #159 
Fix #144 