### PR TITLE
Add specific warnings for 403 forbidden pages

### DIFF
--- a/tohtml.py
+++ b/tohtml.py
@@ -189,8 +189,8 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick, config):
         if success:
             getTag = tag.td('GET Success', 'class="pass"')
         else:
-            if val['rcode'] == 403:
-                getTag = tag.td('GET Forbidden', 'class="warn"')
+            if 400 <= val['rcode'] <= 499:
+                getTag = tag.td('GET Inaccessible', 'class="warn"')
             else:
                 getTag = tag.td('GET Failure', 'class="fail"')
 

--- a/tohtml.py
+++ b/tohtml.py
@@ -160,7 +160,7 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick, config):
         val = results[item]
         rtime = '(response time: {})'.format(val['rtime'])
 
-        if len(val['messages']) == 0 and len(val['errors']) == 0:
+        if len(val['messages']) == 0 and len(val['errors']) == 0 and len(val['warns']) == 0:
             continue
 
         # uri block
@@ -189,7 +189,10 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick, config):
         if success:
             getTag = tag.td('GET Success', 'class="pass"')
         else:
-            getTag = tag.td('GET Failure', 'class="fail"')
+            if val['rcode'] == 403:
+                getTag = tag.td('GET Forbidden', 'class="warn"')
+            else:
+                getTag = tag.td('GET Failure', 'class="fail"')
 
 
         countsTag = tag.td(infoBlock(val['counts'], split='', ffunc=applyInfoSuccessColor), 'class="log"')

--- a/tohtml.py
+++ b/tohtml.py
@@ -189,11 +189,7 @@ def renderHtml(results, finalCounts, tool_version, startTick, nowTick, config):
         if success:
             getTag = tag.td('GET Success', 'class="pass"')
         else:
-            if 400 <= val['rcode'] <= 499:
-                getTag = tag.td('GET Inaccessible', 'class="warn"')
-            else:
-                getTag = tag.td('GET Failure', 'class="fail"')
-
+            getTag = tag.td('GET Inaccessible', 'class="warn"')
 
         countsTag = tag.td(infoBlock(val['counts'], split='', ffunc=applyInfoSuccessColor), 'class="log"')
 

--- a/traverseInterop.py
+++ b/traverseInterop.py
@@ -173,6 +173,7 @@ class rfService():
                 config['certificatecheck'], config['certificatebundle'], config['timeout'], config['token']
         # CacheMode, CacheDir = config['cachemode'], config['cachefilepath']
 
+
         scheme, netloc, path, params, query, fragment = urlparse(URILink)
         inService = scheme == '' and netloc == ''
         if inService:
@@ -196,7 +197,7 @@ class rfService():
 
         # determine if we need to Auth...
         if inService:
-            noauthchk =  URILink in ['/redfish', '/redfish/v1', '/redfish/v1/odata'] or\
+            noauthchk = URILink in ['/redfish', '/redfish/v1', '/redfish/v1/odata'] or\
                 '/redfish/v1/$metadata' in URILink
 
             auth = None if noauthchk else (config.get('username'), config.get('password'))
@@ -253,19 +254,16 @@ class rfService():
                     # navigate fragment
                     decoded = navigateJsonFragment(decoded, URILink)
                     if decoded is None:
-                        traverseLogger.error(
-                                "The JSON pointer in the fragment of this URI is not constructed properly: {}".format(URILink))
+                        traverseLogger.error("The JSON pointer in the fragment of this URI is not constructed properly: {}".format(URILink))
                 elif 'application/xml' in contenttype:
                     decoded = response.text
                 elif 'text/xml' in contenttype:
                     # non-service schemas can use "text/xml" Content-Type
                     if inService:
-                        traverseLogger.warning(
-                                "Incorrect content type 'text/xml' for file within service {}".format(URILink))
+                        traverseLogger.warning("Incorrect content type 'text/xml' for file within service {}".format(URILink))
                     decoded = response.text
                 else:
-                    traverseLogger.error(
-                            "This URI did NOT return XML or Json contenttype, is this not a Redfish resource (is this redirected?): {}".format(URILink))
+                    traverseLogger.error("This URI did NOT return XML or Json contenttype, is this not a Redfish resource (is this redirected?): {}".format(URILink))
                     decoded = None
                     if isXML:
                         traverseLogger.info('Attempting to interpret as XML')
@@ -287,6 +285,9 @@ class rfService():
                         cred_type = 'username and password'
                     raise AuthenticationError('Error accessing URI {}. Status code "{} {}". Check {} supplied for "{}" authentication.\nAborting test due to invalid credentials.'
                                               .format(URILink, statusCode, responses[statusCode], cred_type, AuthType))
+            elif statusCode == 403:
+                # Forbidden but not missing
+                return False, None, statusCode, elapsed
 
         except requests.exceptions.SSLError as e:
             traverseLogger.error("SSLError on {}: {}".format(URILink, repr(e)))
@@ -330,14 +331,14 @@ def createResourceObject(name, uri, jsondata=None, typename=None, context=None, 
         success, jsondata, status, rtime = callResourceURI(uri)
         traverseLogger.debug('{}, {}, {}'.format(success, jsondata, status))
         if not success:
-            traverseLogger.error(
-                '{}:  URI could not be acquired: {}'.format(uri, status))
-            return None
+            if status != 403:
+                my_logger.error('{}:  URI could not be acquired: {}'.format(uri, status))
+            return None, status
     else:
         success, jsondata, status, rtime = True, jsondata, -1, 0
     newResource = ResourceObj(name, uri, jsondata, typename, context, parent, isComplex, topVersion=topVersion, top_of_resource=top_of_resource)
 
-    return newResource
+    return newResource, status
 
 
 class ResourceObj:
@@ -354,14 +355,6 @@ class ResourceObj:
         oem = config.get('oemcheck', True)
         acquiredtype = typename if forceType else jsondata.get('@odata.type', typename)
 
-        # # Check if this is a Registry resource
-        # parent_type = parent.typename if parent is not None and parent is not None else None
-        # if parent_type is not None and getType(parent_type) == 'MessageRegistryFile' or\
-        #         getType(acquiredtype) in ['MessageRegistry', 'AttributeRegistry', 'PrivilegeRegistry']:
-        #     traverseLogger.debug('{} is a Registry resource'.format(self.uri))
-        #     self.isRegistry = True
-        #     self.context = None
-        #     context = None
         if topVersion is not None:
             parent_type = topVersion
 
@@ -474,45 +467,3 @@ class ResourceObj:
             messages[key] = (decoded[key], 'odata',
                             'Exists',
                             'PASS' if paramPass else 'FAIL')
-            
-        return success, messages
-
-
-def enumerate_collection(items, cTypeName, linklimits, sample_size):
-    """
-    Generator function to enumerate the items in a collection, applying the link limit or sample size if applicable.
-    If a link limit is specified for this cTypeName, return the first N items as specified by the limit value.
-    If a sample size greater than zero is specified, return a random sample of items specified by the sample_size.
-    In both the above cases, if the limit value or sample size is greater than or equal to the number of items in the
-    collection, return all the items.
-    If a limit value for this cTypeName and a sample size are both provided, the limit value takes precedence.
-    :param items: the collection of items to enumerate
-    :param cTypeName: the type name of this collection
-    :param linklimits: a dictionary mapping type names to their limit values
-    :param sample_size: the number of items to sample from large collections
-    :return: enumeration of the items to be processed
-    """
-    if cTypeName in linklimits:
-        # "link limit" case
-        limit = min(linklimits[cTypeName], len(items))
-        traverseLogger.debug('Limiting "{}" to first {} links'.format(cTypeName, limit))
-        for i in range(limit):
-            if linklimits[cTypeName] < len(items):
-                uri = items[i].get('@odata.id')
-                if uri is not None:
-                    uri_sample_map[uri] = 'Collection limit {} of {}'.format(i + 1, limit)
-            yield i, items[i]
-    elif 0 < sample_size < len(items):
-        # "sample size" case
-        traverseLogger.debug('Limiting "{}" to sample of {} links'.format(cTypeName, sample_size))
-        sample = 0
-        for i in sorted(random.sample(range(len(items)), sample_size)):
-            sample += 1
-            uri = items[i].get('@odata.id')
-            if uri is not None:
-                uri_sample_map[uri] = 'Collection sample {} of {}'.format(sample, sample_size)
-            yield i, items[i]
-    else:
-        # "all" case
-        traverseLogger.debug('Processing all links for "{}"'.format(cTypeName))
-        yield from enumerate(items)

--- a/traverseInterop.py
+++ b/traverseInterop.py
@@ -331,7 +331,7 @@ def createResourceObject(name, uri, jsondata=None, typename=None, context=None, 
         success, jsondata, status, rtime = callResourceURI(uri)
         traverseLogger.debug('{}, {}, {}'.format(success, jsondata, status))
         if not success:
-            if status != 403:
+            if not (400 <= status <= 499):
                 my_logger.error('{}:  URI could not be acquired: {}'.format(uri, status))
             return None, status
     else:

--- a/traverseInterop.py
+++ b/traverseInterop.py
@@ -285,8 +285,8 @@ class rfService():
                         cred_type = 'username and password'
                     raise AuthenticationError('Error accessing URI {}. Status code "{} {}". Check {} supplied for "{}" authentication.\nAborting test due to invalid credentials.'
                                               .format(URILink, statusCode, responses[statusCode], cred_type, AuthType))
-            elif statusCode == 403:
-                # Forbidden but not missing
+            elif statusCode >= 400:
+                # Error accessing the resource (beyond auth errors)
                 return False, None, statusCode, elapsed
 
         except requests.exceptions.SSLError as e:
@@ -331,8 +331,7 @@ def createResourceObject(name, uri, jsondata=None, typename=None, context=None, 
         success, jsondata, status, rtime = callResourceURI(uri)
         traverseLogger.debug('{}, {}, {}'.format(success, jsondata, status))
         if not success:
-            if not (400 <= status <= 499):
-                my_logger.error('{}:  URI could not be acquired: {}'.format(uri, status))
+            my_logger.error('{}:  URI could not be acquired: {}'.format(uri, status))
             return None, status
     else:
         success, jsondata, status, rtime = True, jsondata, -1, 0

--- a/validateResource.py
+++ b/validateResource.py
@@ -88,14 +88,14 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
 
         results[uriName]['rcode'] = return_status
 
-        if not resource_obj :
+        if not resource_obj:
             counts['inaccessibleResource'] += 1
             my_logger.warning('{}:  This resource is inaccessible and cannot be validated or traversed for links.'.format(URI))
             results[uriName]['warns'] = get_my_capture(my_logger, whandler)
             results[uriName]['payload'] = {}
             return False, counts, results, None, None
         else:
-            results[uriName]['payload'] = propResourceObj.jsondata
+            results[uriName]['payload'] = resource_obj.jsondata
 
     except traverseInterop.AuthenticationError as e:
         raise  # re-raise exception

--- a/validateResource.py
+++ b/validateResource.py
@@ -89,8 +89,8 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
         results[uriName]['rcode'] = return_status
 
         if not propResourceObj:
-            if return_status in [403]:
-                counts['forbiddenResource'] += 1
+            if 400 <= return_status <= 499:
+                counts['inaccessibleResource'] += 1
                 my_logger.warning('{}:  This resource is forbidden or inaccessible, and cannot be validated or traversed for links.'.format(URI))
             else:
                 counts['problemResource'] += 1

--- a/validateResource.py
+++ b/validateResource.py
@@ -89,12 +89,9 @@ def validateSingleURI(URI, profile, uriName='', expectedType=None, expectedSchem
         results[uriName]['rcode'] = return_status
 
         if not propResourceObj:
-            if 400 <= return_status <= 499:
-                counts['inaccessibleResource'] += 1
-                my_logger.warning('{}:  This resource is forbidden or inaccessible, and cannot be validated or traversed for links.'.format(URI))
-            else:
-                counts['problemResource'] += 1
-            results[uriName]['warns'], results[uriName]['errors'] = get_my_capture(my_logger, whandler), get_my_capture(my_logger, ehandler)
+            counts['inaccessibleResource'] += 1
+            my_logger.warning('{}:  This resource is inaccessible and cannot be validated or traversed for links.'.format(URI))
+            results[uriName]['warns'] = get_my_capture(my_logger, whandler)
             results[uriName]['payload'] = {}
             return False, counts, results, None, None
         else:


### PR DESCRIPTION
Adds specific warnings for 403 pages, where the service might be unable to validate or traverse deeper into the resource tree.

Remove dated comments and code, propagate warning messages to HTML page, even if there are no important messages otherwise.

Fixes #166 

[logs.zip](https://github.com/DMTF/Redfish-Interop-Validator/files/11265809/logs.zip)
