### PR TITLE
Add 'online_profiles' Value To config_struct

### DIFF
--- a/redfish_interop_validator/config.py
+++ b/redfish_interop_validator/config.py
@@ -11,7 +11,7 @@ my_logger.setLevel(logging.DEBUG)
 config_struct = {
     'Tool': ['verbose'],
     'Host': ['ip', 'username', 'password', 'description', 'forceauth', 'authtype', 'token'],
-    'Validator': ['payload', 'logdir', 'oemcheck', 'debugging', 'required_profiles_dir', 'collectionlimit']
+    'Validator': ['payload', 'logdir', 'oemcheck', 'online_profiles', 'debugging', 'required_profiles_dir', 'collectionlimit']
 }
 
 config_options = [x for name in config_struct for x in config_struct[name]]


### PR DESCRIPTION
Current version of validator (2.1.9) returns `Option online_profiles not supported!` while validating the config file. This param, as noted in the [README](https://github.com/DMTF/Redfish-Interop-Validator#validator), is supported in the `[Validator]` section of the config file.

Changes:
- config.py: add 'online_profiles' to 'config_struct'. This will prevent the "not supported" error during initialization.

Note: functionality still works, despite error.