### PR TITLE
Fix bug in use case detection

### DIFF
--- a/redfish_interop_validator/validateResource.py
+++ b/redfish_interop_validator/validateResource.py
@@ -346,7 +346,7 @@ def validateURITree(URI, profile, uriName, expectedType=None, expectedSchema=Non
                     resource_stats[SchemaType]['Exists'] = True
                     resource_stats[SchemaType]['URIsFound'].append(link.rstrip('/'))
                     resource_stats[SchemaType]['SubordinateTo'].add(tuple(reversed(subordinate_tree)))
-                    resource_stats[SchemaType]['UseCasesFound'].union(usecases_found)
+                    resource_stats[SchemaType]['UseCasesFound'] = resource_stats[SchemaType]['UseCasesFound'].union(usecases_found)
 
             if refLinks is not currentLinks and len(newLinks) == 0 and len(refLinks) > 0:
                 currentLinks = refLinks


### PR DESCRIPTION
This fixes an issue that prevents use cases from being detected if there is another resource of the same type but not in the use case under the same path prefix (e.g. if you have `/redfish/v1/Systems/<system-name>/Processor1` and `/redfish/v1/Systems/<system-name>/Processor2`, Processor2's use case won't be detected if it's different from Processor1).  