### PR TITLE
Hide password and token parameters from console output when running the tool from a config file

### DIFF
--- a/redfish_interop_validator/config.py
+++ b/redfish_interop_validator/config.py
@@ -53,6 +53,8 @@ def convert_config_to_args(args, config):
                         setattr(args, option, my_config[section][option].split(' '))
                     else:
                         setattr(args, option, my_config[section][option])
+                    if option.lower() in ['password', 'token']:
+                        my_config.set(section, option, '******')
     my_config_dict = config_parse_to_dict(my_config)
     import json
     print(json.dumps(my_config_dict, indent=4))


### PR DESCRIPTION
Fix #208 