### PR TITLE
Do not crash if all a profile does is require other profiles

### DIFF
--- a/redfish_interop_validator/profile.py
+++ b/redfish_interop_validator/profile.py
@@ -176,7 +176,7 @@ def getProfiles(profile, directories, chain=None, online=False):
             required_by_resource.extend(inner_reqs)
         
     # Process all RequiredResourceProfile by modifying profiles
-    profile_resources = profile.get('Resources')
+    profile_resources = profile.get('Resources', {})
     
     for resource_name, resource in profile_resources.items():
         # Modify just the resource or its UseCases.  Should not have concurrent UseCases and RequiredResourceProfile in Resource


### PR DESCRIPTION
The Validator currently crashes if a profile is only used to require other profiles. Added a default value for the resource dictionary to fix this.